### PR TITLE
Add service charge support with persistence

### DIFF
--- a/src/br/ufal/ic/p2/wepayu/Facade.java
+++ b/src/br/ufal/ic/p2/wepayu/Facade.java
@@ -10,6 +10,7 @@ public class Facade {
     }
 
     public void encerrarSistema(){
+        Database.encerrarSistema();
     }
 
     public String criarEmpregado(String nome, String endereco, String tipo, String salario) {
@@ -25,6 +26,9 @@ public class Facade {
     }
 
     public String getAtributoEmpregado(String empId, String atributo) {
+        if (atributo == null) {
+            throw new IllegalArgumentException("Atributo nao pode ser nulo.");
+        }
         Empregado e = Database.getEmpregado(empId);
 
         switch (atributo.toLowerCase()) {
@@ -38,6 +42,16 @@ public class Facade {
                 }
                 return String.format("%.2f", e.getComissao()).replace('.', ',');
             case "sindicalizado": return String.valueOf(e.isSindicalizado());
+            case "idsindicato":
+                if (!e.isSindicalizado()) {
+                    throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+                }
+                return e.getIdSindicato();
+            case "taxasindical":
+                if (!e.isSindicalizado()) {
+                    throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+                }
+                return String.format("%.2f", e.getTaxaSindical()).replace('.', ',');
             default: throw new IllegalArgumentException("Atributo nao existe.");
         }
     }
@@ -54,11 +68,35 @@ public class Facade {
         Database.lancaCartao(empId, data, horas);
     }
 
+    public void lancaVenda(String empId, String data, String valor) {
+        Database.lancaVenda(empId, data, valor);
+    }
+
+    public void lancaTaxaServico(String membroId, String data, String valor) {
+        Database.lancaTaxaServico(membroId, data, valor);
+    }
+
     public String getHorasNormaisTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return Database.getHorasNormaisTrabalhadas(empId, dataInicial, dataFinal);
     }
     public String getHorasExtrasTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return Database.getHorasExtrasTrabalhadas(empId, dataInicial, dataFinal);
+    }
+
+    public String getVendasRealizadas(String empId, String dataInicial, String dataFinal) {
+        return Database.getVendasRealizadas(empId, dataInicial, dataFinal);
+    }
+
+    public String getTaxasServico(String empId, String dataInicial, String dataFinal) {
+        return Database.getTaxasServico(empId, dataInicial, dataFinal);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor) {
+        Database.alteraEmpregado(empId, atributo, valor);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor, String idSindicato, String taxaSindical) {
+        Database.alteraEmpregado(empId, atributo, valor, idSindicato, taxaSindical);
     }
 
 }

--- a/src/br/ufal/ic/p2/wepayu/models/CartaoPonto.java
+++ b/src/br/ufal/ic/p2/wepayu/models/CartaoPonto.java
@@ -1,6 +1,8 @@
 package br.ufal.ic.p2.wepayu.models;
 
-public class CartaoPonto {
+import java.io.Serializable;
+
+public class CartaoPonto implements Serializable {
     private String data;
     private double horas;
 

--- a/src/br/ufal/ic/p2/wepayu/models/Database.java
+++ b/src/br/ufal/ic/p2/wepayu/models/Database.java
@@ -1,11 +1,17 @@
 package br.ufal.ic.p2.wepayu.models;
 
+import java.io.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
 public class Database {
+    private static final String ARQUIVO = "empregados.ser";
     private static Map<String, Empregado> empregados = new HashMap<>();
+
+    static {
+        carregar();
+    }
 
     public static void adicionarEmpregado(Empregado empregado) {
         empregados.put(empregado.getId(), empregado);
@@ -55,6 +61,73 @@ public class Database {
         return encontrados.get(indice - 1).getId();
     }
 
+    public static void alteraEmpregado(String empId, String atributo, String valor) {
+        Empregado e = getEmpregado(empId);
+
+        if (!"sindicalizado".equalsIgnoreCase(atributo)) {
+            throw new IllegalArgumentException("Atributo nao existe.");
+        }
+
+        if (valor == null || (!valor.equalsIgnoreCase("true") && !valor.equalsIgnoreCase("false"))) {
+            throw new IllegalArgumentException("Valor deve ser true ou false.");
+        }
+
+        if (valor.equalsIgnoreCase("true")) {
+            throw new IllegalArgumentException("Identificacao do sindicato nao pode ser nula.");
+        }
+
+        e.setSindicalizado(false);
+        e.setIdSindicato(null);
+        e.setTaxaSindical(0);
+    }
+
+    public static void alteraEmpregado(String empId, String atributo, String valor,
+                                       String idSindicato, String taxaSindical) {
+        Empregado e = getEmpregado(empId);
+
+        if (!"sindicalizado".equalsIgnoreCase(atributo)) {
+            throw new IllegalArgumentException("Atributo nao existe.");
+        }
+
+        if (valor == null || (!valor.equalsIgnoreCase("true") && !valor.equalsIgnoreCase("false"))) {
+            throw new IllegalArgumentException("Valor deve ser true ou false.");
+        }
+
+        if (valor.equalsIgnoreCase("false")) {
+            e.setSindicalizado(false);
+            e.setIdSindicato(null);
+            e.setTaxaSindical(0);
+            return;
+        }
+
+        if (idSindicato == null || idSindicato.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do sindicato nao pode ser nula.");
+        }
+        if (taxaSindical == null || taxaSindical.trim().isEmpty()) {
+            throw new IllegalArgumentException("Taxa sindical nao pode ser nula.");
+        }
+
+        double taxa;
+        try {
+            taxa = Double.parseDouble(taxaSindical.replace(",", "."));
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Taxa sindical deve ser numerica.");
+        }
+        if (taxa < 0) {
+            throw new IllegalArgumentException("Taxa sindical deve ser nao-negativa.");
+        }
+
+        for (Empregado outro : empregados.values()) {
+            if (outro != e && outro.isSindicalizado() && idSindicato.equals(outro.getIdSindicato())) {
+                throw new IllegalArgumentException("Ha outro empregado com esta identificacao de sindicato");
+            }
+        }
+
+        e.setSindicalizado(true);
+        e.setIdSindicato(idSindicato);
+        e.setTaxaSindical(taxa);
+    }
+
     public static void lancaCartao(String empId, String data, String horas) {
         if (empId == null || empId.trim().isEmpty()) {
             throw new IllegalArgumentException("Identificacao do empregado nao pode ser nula.");
@@ -72,12 +145,102 @@ public class Database {
         e.adicionarCartao(cartao);
     }
 
+    public static void lancaVenda(String empId, String data, String valor) {
+        if (empId == null || empId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do empregado nao pode ser nula.");
+        }
+
+        Empregado e = getEmpregado(empId);
+
+        if (!e.getTipo().equals("comissionado")) {
+            throw new IllegalArgumentException("Empregado nao eh comissionado.");
+        }
+
+        validarData(data, false);
+
+        Venda v = new Venda(data, valor);
+        e.adicionarVenda(v);
+    }
+
+    public static void lancaTaxaServico(String membroId, String data, String valor) {
+        if (membroId == null || membroId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do membro nao pode ser nula.");
+        }
+
+        Empregado e = null;
+        for (Empregado emp : empregados.values()) {
+            if (emp.isSindicalizado() && membroId.equals(emp.getIdSindicato())) {
+                e = emp;
+                break;
+            }
+        }
+
+        if (e == null) {
+            throw new IllegalArgumentException("Membro nao existe.");
+        }
+
+        validarData(data, false);
+
+        TaxaServico t = new TaxaServico(data, valor);
+        e.adicionarTaxa(t);
+    }
+
     public static String getHorasNormaisTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return formatarNumero(calcularHoras(empId, dataInicial, dataFinal, false));
     }
 
     public static String getHorasExtrasTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return formatarNumero(calcularHoras(empId, dataInicial, dataFinal, true));
+    }
+
+    public static String getTaxasServico(String empId, String dataInicial, String dataFinal) {
+        Empregado e = getEmpregado(empId);
+
+        if (!e.isSindicalizado()) {
+            throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+        }
+
+        Date inicio = validarData(dataInicial, true);
+        Date fim = validarData(dataFinal, false);
+
+        if (inicio.after(fim)) {
+            throw new IllegalArgumentException("Data inicial nao pode ser posterior aa data final.");
+        }
+
+        double total = 0;
+        for (TaxaServico t : e.getTaxas()) {
+            Date d = validarData(t.getData(), false);
+            if (!d.before(inicio) && d.before(fim)) {
+                total += t.getValor();
+            }
+        }
+
+        return formatarValor(total);
+    }
+
+    public static String getVendasRealizadas(String empId, String dataInicial, String dataFinal) {
+        Empregado e = getEmpregado(empId);
+
+        if (!e.getTipo().equals("comissionado")) {
+            throw new IllegalArgumentException("Empregado nao eh comissionado.");
+        }
+
+        Date inicio = validarData(dataInicial, true);
+        Date fim = validarData(dataFinal, false);
+
+        if (inicio.after(fim)) {
+            throw new IllegalArgumentException("Data inicial nao pode ser posterior aa data final.");
+        }
+
+        double total = 0;
+        for (Venda v : e.getVendas()) {
+            Date data = validarData(v.getData(), false);
+            if (!data.before(inicio) && data.before(fim)) {
+                total += v.getValor();
+            }
+        }
+
+        return formatarValor(total);
     }
 
     private static double calcularHoras(String empId, String dataInicial, String dataFinal, boolean extras) {
@@ -165,7 +328,39 @@ public class Database {
         }
     }
 
+    private static String formatarValor(double valor) {
+        return String.format("%.2f", valor).replace('.', ',');
+    }
+
+    private static void carregar() {
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(ARQUIVO))) {
+            Object obj = in.readObject();
+            if (obj instanceof Map) {
+                empregados = (Map<String, Empregado>) obj;
+            }
+        } catch (Exception e) {
+            empregados = new HashMap<>();
+        }
+    }
+
+    private static void salvar() {
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(ARQUIVO))) {
+            out.writeObject(empregados);
+        } catch (IOException e) {
+            // ignora problemas de IO
+        }
+    }
+
+    public static void encerrarSistema() {
+        salvar();
+    }
+
     public static void zerarSistema() {
         empregados.clear();
+        Empregado.resetContador();
+        File f = new File(ARQUIVO);
+        if (f.exists()) {
+            f.delete();
+        }
     }
 }

--- a/src/br/ufal/ic/p2/wepayu/models/Empregado.java
+++ b/src/br/ufal/ic/p2/wepayu/models/Empregado.java
@@ -1,9 +1,11 @@
 package br.ufal.ic.p2.wepayu.models;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
 
-public class Empregado {
+public class Empregado implements Serializable {
     private static int contadorId = 1;
     private String id;
     private String nome;
@@ -12,8 +14,11 @@ public class Empregado {
     private double salario;
     private Double comissao;
     private boolean sindicalizado;
+    private String idSindicato;
+    private double taxaSindical;
     private List<CartaoPonto> cartoes = new ArrayList<>();
     private List<Venda> vendas = new ArrayList<>();
+    private List<TaxaServico> taxas = new ArrayList<>();
 
     public Empregado(String nome, String endereco, String tipo, String salarioStr, String comissaoStr) {
         if (nome == null || nome.trim().isEmpty()) {
@@ -68,6 +73,8 @@ public class Empregado {
         this.endereco = endereco;
         this.tipo = tipo.toLowerCase();
         this.sindicalizado = false;
+        this.idSindicato = null;
+        this.taxaSindical = 0;
     }
 
     // ---- cartões ----
@@ -76,7 +83,7 @@ public class Empregado {
     }
 
     public List<CartaoPonto> getCartoes() {
-        return cartoes;
+        return Collections.unmodifiableList(cartoes);
     }
 
     // ---- vendas ----
@@ -85,8 +92,21 @@ public class Empregado {
     }
 
     public List<Venda> getVendas() {
-        return vendas;
+        return Collections.unmodifiableList(vendas);
     }
+
+    // ---- taxas de servico ----
+    public void adicionarTaxa(TaxaServico t) {
+        taxas.add(t);
+    }
+
+    public List<TaxaServico> getTaxas() {
+        return Collections.unmodifiableList(taxas);
+    }
+
+    public void setSindicalizado(boolean valor) { this.sindicalizado = valor; }
+    public void setIdSindicato(String id) { this.idSindicato = id; }
+    public void setTaxaSindical(double taxa) { this.taxaSindical = taxa; }
 
     // ---- getters ----
     public String getId() { return id; }
@@ -96,4 +116,10 @@ public class Empregado {
     public double getSalario() { return salario; }
     public Double getComissao() { return comissao; }
     public boolean isSindicalizado() { return sindicalizado; }
+    public String getIdSindicato() { return idSindicato; }
+    public double getTaxaSindical() { return taxaSindical; }
+
+    public static void resetContador() {
+        contadorId = 1;
+    }
 }

--- a/src/br/ufal/ic/p2/wepayu/models/TaxaServico.java
+++ b/src/br/ufal/ic/p2/wepayu/models/TaxaServico.java
@@ -4,11 +4,11 @@ import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
-public class Venda implements Serializable {
+public class TaxaServico implements Serializable {
     private String data;
     private double valor;
 
-    public Venda(String data, String valorStr) {
+    public TaxaServico(String data, String valorStr) {
         if (data == null || data.trim().isEmpty()) {
             throw new IllegalArgumentException("Data invalida.");
         }


### PR DESCRIPTION
## Summary
- manage union membership and service charges for employees
- persist employee data between sessions using serialization
- expose APIs to launch and query service charges

## Testing
- `javac -cp lib/easyaccept.jar -d bin $(find src -name "*.java")`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us2.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us3.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us4.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us5.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us5_1.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c4d350027483249aa0eb1c1812ddb8