### PR TITLE
Add service charge support with persistence

### DIFF
--- a/src/br/ufal/ic/p2/wepayu/Facade.java
+++ b/src/br/ufal/ic/p2/wepayu/Facade.java
@@ -10,6 +10,7 @@ public class Facade {
     }
 
     public void encerrarSistema(){
+        Database.encerrarSistema();
     }
 
     public String criarEmpregado(String nome, String endereco, String tipo, String salario) {
@@ -25,6 +26,9 @@ public class Facade {
     }
 
     public String getAtributoEmpregado(String empId, String atributo) {
+        if (atributo == null) {
+            throw new IllegalArgumentException("Atributo nao pode ser nulo.");
+        }
         Empregado e = Database.getEmpregado(empId);
 
         switch (atributo.toLowerCase()) {
@@ -33,11 +37,38 @@ public class Facade {
             case "tipo": return e.getTipo();
             case "salario": return String.format("%.2f", e.getSalario()).replace('.', ',');
             case "comissao":
-                if (e.getComissao() == null) {
-                    throw new IllegalArgumentException("Atributo nao existe.");
+                if (!"comissionado".equals(e.getTipo())) {
+                    throw new IllegalArgumentException("Empregado nao eh comissionado.");
                 }
                 return String.format("%.2f", e.getComissao()).replace('.', ',');
             case "sindicalizado": return String.valueOf(e.isSindicalizado());
+            case "idsindicato":
+                if (!e.isSindicalizado()) {
+                    throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+                }
+                return e.getIdSindicato();
+            case "taxasindical":
+                if (!e.isSindicalizado()) {
+                    throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+                }
+                return String.format("%.2f", e.getTaxaSindical()).replace('.', ',');
+            case "metodopagamento":
+                return e.getMetodoPagamento();
+            case "banco":
+                if (!"banco".equals(e.getMetodoPagamento())) {
+                    throw new IllegalArgumentException("Empregado nao recebe em banco.");
+                }
+                return e.getBanco();
+            case "agencia":
+                if (!"banco".equals(e.getMetodoPagamento())) {
+                    throw new IllegalArgumentException("Empregado nao recebe em banco.");
+                }
+                return e.getAgencia();
+            case "contacorrente":
+                if (!"banco".equals(e.getMetodoPagamento())) {
+                    throw new IllegalArgumentException("Empregado nao recebe em banco.");
+                }
+                return e.getContaCorrente();
             default: throw new IllegalArgumentException("Atributo nao existe.");
         }
     }
@@ -54,11 +85,43 @@ public class Facade {
         Database.lancaCartao(empId, data, horas);
     }
 
+    public void lancaVenda(String empId, String data, String valor) {
+        Database.lancaVenda(empId, data, valor);
+    }
+
+    public void lancaTaxaServico(String membroId, String data, String valor) {
+        Database.lancaTaxaServico(membroId, data, valor);
+    }
+
     public String getHorasNormaisTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return Database.getHorasNormaisTrabalhadas(empId, dataInicial, dataFinal);
     }
     public String getHorasExtrasTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return Database.getHorasExtrasTrabalhadas(empId, dataInicial, dataFinal);
+    }
+
+    public String getVendasRealizadas(String empId, String dataInicial, String dataFinal) {
+        return Database.getVendasRealizadas(empId, dataInicial, dataFinal);
+    }
+
+    public String getTaxasServico(String empId, String dataInicial, String dataFinal) {
+        return Database.getTaxasServico(empId, dataInicial, dataFinal);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor) {
+        Database.alteraEmpregado(empId, atributo, valor);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor, String valor2) {
+        Database.alteraEmpregado(empId, atributo, valor, valor2);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor, String idSindicato, String taxaSindical) {
+        Database.alteraEmpregado(empId, atributo, valor, idSindicato, taxaSindical);
+    }
+
+    public void alteraEmpregado(String empId, String atributo, String valor1, String banco, String agencia, String contaCorrente) {
+        Database.alteraEmpregado(empId, atributo, valor1, banco, agencia, contaCorrente);
     }
 
 }

--- a/src/br/ufal/ic/p2/wepayu/models/CartaoPonto.java
+++ b/src/br/ufal/ic/p2/wepayu/models/CartaoPonto.java
@@ -1,6 +1,8 @@
 package br.ufal.ic.p2.wepayu.models;
 
-public class CartaoPonto {
+import java.io.Serializable;
+
+public class CartaoPonto implements Serializable {
     private String data;
     private double horas;
 

--- a/src/br/ufal/ic/p2/wepayu/models/Database.java
+++ b/src/br/ufal/ic/p2/wepayu/models/Database.java
@@ -1,11 +1,17 @@
 package br.ufal.ic.p2.wepayu.models;
 
+import java.io.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
 public class Database {
+    private static final String ARQUIVO = "empregados.ser";
     private static Map<String, Empregado> empregados = new HashMap<>();
+
+    static {
+        carregar();
+    }
 
     public static void adicionarEmpregado(Empregado empregado) {
         empregados.put(empregado.getId(), empregado);
@@ -55,6 +61,232 @@ public class Database {
         return encontrados.get(indice - 1).getId();
     }
 
+    public static void alteraEmpregado(String empId, String atributo, String valor) {
+        Empregado e = getEmpregado(empId);
+
+        switch (atributo.toLowerCase()) {
+            case "nome":
+                if (valor == null || valor.trim().isEmpty()) {
+                    throw new IllegalArgumentException("Nome nao pode ser nulo.");
+                }
+                e.setNome(valor);
+                break;
+            case "endereco":
+                if (valor == null || valor.trim().isEmpty()) {
+                    throw new IllegalArgumentException("Endereco nao pode ser nulo.");
+                }
+                e.setEndereco(valor);
+                break;
+            case "tipo":
+                if (valor == null ||
+                        !(valor.equalsIgnoreCase("horista") || valor.equalsIgnoreCase("assalariado") || valor.equalsIgnoreCase("comissionado"))) {
+                    throw new IllegalArgumentException("Tipo invalido.");
+                }
+                e.setTipo(valor.toLowerCase());
+                if (!valor.equalsIgnoreCase("comissionado")) {
+                    e.setComissao(null);
+                }
+                break;
+            case "salario":
+                if (valor == null || valor.trim().isEmpty()) {
+                    throw new IllegalArgumentException("Salario nao pode ser nulo.");
+                }
+                double sal;
+                try {
+                    sal = Double.parseDouble(valor.replace(",", "."));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Salario deve ser numerico.");
+                }
+                if (sal < 0) {
+                    throw new IllegalArgumentException("Salario deve ser nao-negativo.");
+                }
+                e.setSalario(sal);
+                break;
+            case "comissao":
+                if (!"comissionado".equals(e.getTipo())) {
+                    throw new IllegalArgumentException("Empregado nao eh comissionado.");
+                }
+                if (valor == null || valor.trim().isEmpty()) {
+                    throw new IllegalArgumentException("Comissao nao pode ser nula.");
+                }
+                double com;
+                try {
+                    com = Double.parseDouble(valor.replace(",", "."));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Comissao deve ser numerica.");
+                }
+                if (com < 0) {
+                    throw new IllegalArgumentException("Comissao deve ser nao-negativa.");
+                }
+                e.setComissao(com);
+                break;
+            case "metodopagamento":
+                if (valor == null) {
+                    throw new IllegalArgumentException("Metodo de pagamento invalido.");
+                }
+                if (valor.equalsIgnoreCase("emmaos")) {
+                    e.setMetodoPagamento("emMaos");
+                    e.setBanco(null); e.setAgencia(null); e.setContaCorrente(null);
+                } else if (valor.equalsIgnoreCase("correios")) {
+                    e.setMetodoPagamento("correios");
+                    e.setBanco(null); e.setAgencia(null); e.setContaCorrente(null);
+                } else if (valor.equalsIgnoreCase("banco")) {
+                    throw new IllegalArgumentException("Banco nao pode ser nulo.");
+                } else {
+                    throw new IllegalArgumentException("Metodo de pagamento invalido.");
+                }
+                break;
+            case "sindicalizado":
+                if (valor == null || (!valor.equalsIgnoreCase("true") && !valor.equalsIgnoreCase("false"))) {
+                    throw new IllegalArgumentException("Valor deve ser true ou false.");
+                }
+                if (valor.equalsIgnoreCase("true")) {
+                    throw new IllegalArgumentException("Identificacao do sindicato nao pode ser nula.");
+                }
+                e.setSindicalizado(false);
+                e.setIdSindicato(null);
+                e.setTaxaSindical(0);
+                break;
+            default:
+                throw new IllegalArgumentException("Atributo nao existe.");
+        }
+    }
+
+    public static void alteraEmpregado(String empId, String atributo, String valor,
+                                       String idSindicato, String taxaSindical) {
+        Empregado e = getEmpregado(empId);
+
+        if (!"sindicalizado".equalsIgnoreCase(atributo)) {
+            throw new IllegalArgumentException("Atributo nao existe.");
+        }
+
+        if (valor == null || (!valor.equalsIgnoreCase("true") && !valor.equalsIgnoreCase("false"))) {
+            throw new IllegalArgumentException("Valor deve ser true ou false.");
+        }
+
+        if (valor.equalsIgnoreCase("false")) {
+            e.setSindicalizado(false);
+            e.setIdSindicato(null);
+            e.setTaxaSindical(0);
+            return;
+        }
+
+        if (idSindicato == null || idSindicato.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do sindicato nao pode ser nula.");
+        }
+        if (taxaSindical == null || taxaSindical.trim().isEmpty()) {
+            throw new IllegalArgumentException("Taxa sindical nao pode ser nula.");
+        }
+
+        double taxa;
+        try {
+            taxa = Double.parseDouble(taxaSindical.replace(",", "."));
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Taxa sindical deve ser numerica.");
+        }
+        if (taxa < 0) {
+            throw new IllegalArgumentException("Taxa sindical deve ser nao-negativa.");
+        }
+
+        for (Empregado outro : empregados.values()) {
+            if (outro != e && outro.isSindicalizado() && idSindicato.equals(outro.getIdSindicato())) {
+                throw new IllegalArgumentException("Ha outro empregado com esta identificacao de sindicato");
+            }
+        }
+
+        e.setSindicalizado(true);
+        e.setIdSindicato(idSindicato);
+        e.setTaxaSindical(taxa);
+    }
+
+    public static void alteraEmpregado(String empId, String atributo, String valor, String valor2) {
+        Empregado e = getEmpregado(empId);
+
+        if (!"tipo".equalsIgnoreCase(atributo)) {
+            throw new IllegalArgumentException("Atributo nao existe.");
+        }
+
+        if (valor == null ||
+                !(valor.equalsIgnoreCase("horista") || valor.equalsIgnoreCase("assalariado") || valor.equalsIgnoreCase("comissionado"))) {
+            throw new IllegalArgumentException("Tipo invalido.");
+        }
+
+        if (valor.equalsIgnoreCase("horista")) {
+            if (valor2 == null || valor2.trim().isEmpty()) {
+                throw new IllegalArgumentException("Salario nao pode ser nulo.");
+            }
+            double sal;
+            try {
+                sal = Double.parseDouble(valor2.replace(",", "."));
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Salario deve ser numerico.");
+            }
+            if (sal < 0) {
+                throw new IllegalArgumentException("Salario deve ser nao-negativo.");
+            }
+            e.setTipo("horista");
+            e.setSalario(sal);
+            e.setComissao(null);
+        } else if (valor.equalsIgnoreCase("comissionado")) {
+            if (valor2 == null || valor2.trim().isEmpty()) {
+                throw new IllegalArgumentException("Comissao nao pode ser nula.");
+            }
+            double com;
+            try {
+                com = Double.parseDouble(valor2.replace(",", "."));
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Comissao deve ser numerica.");
+            }
+            if (com < 0) {
+                throw new IllegalArgumentException("Comissao deve ser nao-negativa.");
+            }
+            e.setTipo("comissionado");
+            e.setComissao(com);
+        } else { // assalariado
+            e.setTipo("assalariado");
+            e.setComissao(null);
+            if (valor2 != null && !valor2.trim().isEmpty()) {
+                double sal;
+                try {
+                    sal = Double.parseDouble(valor2.replace(",", "."));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Salario deve ser numerico.");
+                }
+                if (sal < 0) {
+                    throw new IllegalArgumentException("Salario deve ser nao-negativo.");
+                }
+                e.setSalario(sal);
+            }
+        }
+    }
+
+    public static void alteraEmpregado(String empId, String atributo, String valor1, String banco, String agencia, String contaCorrente) {
+        Empregado e = getEmpregado(empId);
+
+        if (!"metodopagamento".equalsIgnoreCase(atributo)) {
+            throw new IllegalArgumentException("Atributo nao existe.");
+        }
+
+        if (valor1 == null || !valor1.equalsIgnoreCase("banco")) {
+            throw new IllegalArgumentException("Metodo de pagamento invalido.");
+        }
+
+        if (banco == null || banco.trim().isEmpty()) {
+            throw new IllegalArgumentException("Banco nao pode ser nulo.");
+        }
+        if (agencia == null || agencia.trim().isEmpty()) {
+            throw new IllegalArgumentException("Agencia nao pode ser nulo.");
+        }
+        if (contaCorrente == null || contaCorrente.trim().isEmpty()) {
+            throw new IllegalArgumentException("Conta corrente nao pode ser nulo.");
+        }
+
+        e.setMetodoPagamento("banco");
+        e.setBanco(banco);
+        e.setAgencia(agencia);
+        e.setContaCorrente(contaCorrente);
+    }
+
     public static void lancaCartao(String empId, String data, String horas) {
         if (empId == null || empId.trim().isEmpty()) {
             throw new IllegalArgumentException("Identificacao do empregado nao pode ser nula.");
@@ -72,12 +304,102 @@ public class Database {
         e.adicionarCartao(cartao);
     }
 
+    public static void lancaVenda(String empId, String data, String valor) {
+        if (empId == null || empId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do empregado nao pode ser nula.");
+        }
+
+        Empregado e = getEmpregado(empId);
+
+        if (!e.getTipo().equals("comissionado")) {
+            throw new IllegalArgumentException("Empregado nao eh comissionado.");
+        }
+
+        validarData(data, false);
+
+        Venda v = new Venda(data, valor);
+        e.adicionarVenda(v);
+    }
+
+    public static void lancaTaxaServico(String membroId, String data, String valor) {
+        if (membroId == null || membroId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Identificacao do membro nao pode ser nula.");
+        }
+
+        Empregado e = null;
+        for (Empregado emp : empregados.values()) {
+            if (emp.isSindicalizado() && membroId.equals(emp.getIdSindicato())) {
+                e = emp;
+                break;
+            }
+        }
+
+        if (e == null) {
+            throw new IllegalArgumentException("Membro nao existe.");
+        }
+
+        validarData(data, false);
+
+        TaxaServico t = new TaxaServico(data, valor);
+        e.adicionarTaxa(t);
+    }
+
     public static String getHorasNormaisTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return formatarNumero(calcularHoras(empId, dataInicial, dataFinal, false));
     }
 
     public static String getHorasExtrasTrabalhadas(String empId, String dataInicial, String dataFinal) {
         return formatarNumero(calcularHoras(empId, dataInicial, dataFinal, true));
+    }
+
+    public static String getTaxasServico(String empId, String dataInicial, String dataFinal) {
+        Empregado e = getEmpregado(empId);
+
+        if (!e.isSindicalizado()) {
+            throw new IllegalArgumentException("Empregado nao eh sindicalizado.");
+        }
+
+        Date inicio = validarData(dataInicial, true);
+        Date fim = validarData(dataFinal, false);
+
+        if (inicio.after(fim)) {
+            throw new IllegalArgumentException("Data inicial nao pode ser posterior aa data final.");
+        }
+
+        double total = 0;
+        for (TaxaServico t : e.getTaxas()) {
+            Date d = validarData(t.getData(), false);
+            if (!d.before(inicio) && d.before(fim)) {
+                total += t.getValor();
+            }
+        }
+
+        return formatarValor(total);
+    }
+
+    public static String getVendasRealizadas(String empId, String dataInicial, String dataFinal) {
+        Empregado e = getEmpregado(empId);
+
+        if (!e.getTipo().equals("comissionado")) {
+            throw new IllegalArgumentException("Empregado nao eh comissionado.");
+        }
+
+        Date inicio = validarData(dataInicial, true);
+        Date fim = validarData(dataFinal, false);
+
+        if (inicio.after(fim)) {
+            throw new IllegalArgumentException("Data inicial nao pode ser posterior aa data final.");
+        }
+
+        double total = 0;
+        for (Venda v : e.getVendas()) {
+            Date data = validarData(v.getData(), false);
+            if (!data.before(inicio) && data.before(fim)) {
+                total += v.getValor();
+            }
+        }
+
+        return formatarValor(total);
     }
 
     private static double calcularHoras(String empId, String dataInicial, String dataFinal, boolean extras) {
@@ -165,7 +487,39 @@ public class Database {
         }
     }
 
+    private static String formatarValor(double valor) {
+        return String.format("%.2f", valor).replace('.', ',');
+    }
+
+    private static void carregar() {
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(ARQUIVO))) {
+            Object obj = in.readObject();
+            if (obj instanceof Map) {
+                empregados = (Map<String, Empregado>) obj;
+            }
+        } catch (Exception e) {
+            empregados = new HashMap<>();
+        }
+    }
+
+    private static void salvar() {
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(ARQUIVO))) {
+            out.writeObject(empregados);
+        } catch (IOException e) {
+            // ignora problemas de IO
+        }
+    }
+
+    public static void encerrarSistema() {
+        salvar();
+    }
+
     public static void zerarSistema() {
         empregados.clear();
+        Empregado.resetContador();
+        File f = new File(ARQUIVO);
+        if (f.exists()) {
+            f.delete();
+        }
     }
 }

--- a/src/br/ufal/ic/p2/wepayu/models/Empregado.java
+++ b/src/br/ufal/ic/p2/wepayu/models/Empregado.java
@@ -1,9 +1,11 @@
 package br.ufal.ic.p2.wepayu.models;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
 
-public class Empregado {
+public class Empregado implements Serializable {
     private static int contadorId = 1;
     private String id;
     private String nome;
@@ -12,8 +14,15 @@ public class Empregado {
     private double salario;
     private Double comissao;
     private boolean sindicalizado;
+    private String idSindicato;
+    private double taxaSindical;
+    private String metodoPagamento;
+    private String banco;
+    private String agencia;
+    private String contaCorrente;
     private List<CartaoPonto> cartoes = new ArrayList<>();
     private List<Venda> vendas = new ArrayList<>();
+    private List<TaxaServico> taxas = new ArrayList<>();
 
     public Empregado(String nome, String endereco, String tipo, String salarioStr, String comissaoStr) {
         if (nome == null || nome.trim().isEmpty()) {
@@ -68,6 +77,12 @@ public class Empregado {
         this.endereco = endereco;
         this.tipo = tipo.toLowerCase();
         this.sindicalizado = false;
+        this.idSindicato = null;
+        this.taxaSindical = 0;
+        this.metodoPagamento = "emMaos";
+        this.banco = null;
+        this.agencia = null;
+        this.contaCorrente = null;
     }
 
     // ---- cartões ----
@@ -76,7 +91,7 @@ public class Empregado {
     }
 
     public List<CartaoPonto> getCartoes() {
-        return cartoes;
+        return Collections.unmodifiableList(cartoes);
     }
 
     // ---- vendas ----
@@ -85,8 +100,31 @@ public class Empregado {
     }
 
     public List<Venda> getVendas() {
-        return vendas;
+        return Collections.unmodifiableList(vendas);
     }
+
+    // ---- taxas de servico ----
+    public void adicionarTaxa(TaxaServico t) {
+        taxas.add(t);
+    }
+
+    public List<TaxaServico> getTaxas() {
+        return Collections.unmodifiableList(taxas);
+    }
+
+    public void setSindicalizado(boolean valor) { this.sindicalizado = valor; }
+    public void setIdSindicato(String id) { this.idSindicato = id; }
+    public void setTaxaSindical(double taxa) { this.taxaSindical = taxa; }
+
+    public void setNome(String nome) { this.nome = nome; }
+    public void setEndereco(String endereco) { this.endereco = endereco; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
+    public void setSalario(double salario) { this.salario = salario; }
+    public void setComissao(Double comissao) { this.comissao = comissao; }
+    public void setMetodoPagamento(String metodo) { this.metodoPagamento = metodo; }
+    public void setBanco(String banco) { this.banco = banco; }
+    public void setAgencia(String agencia) { this.agencia = agencia; }
+    public void setContaCorrente(String conta) { this.contaCorrente = conta; }
 
     // ---- getters ----
     public String getId() { return id; }
@@ -96,4 +134,14 @@ public class Empregado {
     public double getSalario() { return salario; }
     public Double getComissao() { return comissao; }
     public boolean isSindicalizado() { return sindicalizado; }
+    public String getIdSindicato() { return idSindicato; }
+    public double getTaxaSindical() { return taxaSindical; }
+    public String getMetodoPagamento() { return metodoPagamento; }
+    public String getBanco() { return banco; }
+    public String getAgencia() { return agencia; }
+    public String getContaCorrente() { return contaCorrente; }
+
+    public static void resetContador() {
+        contadorId = 1;
+    }
 }

--- a/src/br/ufal/ic/p2/wepayu/models/TaxaServico.java
+++ b/src/br/ufal/ic/p2/wepayu/models/TaxaServico.java
@@ -4,11 +4,11 @@ import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
-public class Venda implements Serializable {
+public class TaxaServico implements Serializable {
     private String data;
     private double valor;
 
-    public Venda(String data, String valorStr) {
+    public TaxaServico(String data, String valorStr) {
         if (data == null || data.trim().isEmpty()) {
             throw new IllegalArgumentException("Data invalida.");
         }


### PR DESCRIPTION
## Summary
- manage union membership and service charges for employees
- persist employee data between sessions using serialization
- expose APIs to launch and query service charges
- support editing employee attributes including salary, commission, and payment details

## Testing
- `javac -cp lib/easyaccept.jar -d bin $(find src -name "*.java")`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us1_1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us2.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us2_1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us3.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us3_1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us4.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us4_1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us5.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us5_1.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us6.txt`
- `java -cp bin:lib/easyaccept.jar easyaccept.EasyAccept br.ufal.ic.p2.wepayu.Facade tests/us6_1.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c4d350027483249aa0eb1c1812ddb8